### PR TITLE
chore: bump version to 0.1.3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "vaultfolio",
   "name": "VaultFolio",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "minAppVersion": "1.0.0",
   "description": "Turn your Obsidian notes into a live portfolio",
   "author": "Santhosh",


### PR DESCRIPTION
## Summary
- Bumps `manifest.json` version from `0.1.2` to `0.1.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)