### PR TITLE
fix: update theme-preview link to VaultFolio GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Wait 2-3 minutes. Your portfolio will be live.
 
 Change theme in **Settings → VaultFolio → Theme**
 
-Preview live: [theme-preview page](https://thedozcompany.github.io/vaultfolio-portfolio/theme-preview.html)
+Preview live: [theme-preview page](https://thedozcompany.github.io/VaultFolio/theme-preview.html)
 
 ---
 


### PR DESCRIPTION
## Summary

- Updates the theme-preview link in README from the portfolio repo (which gets wiped on every deploy) to the stable VaultFolio plugin repo GitHub Pages URL
- New URL: `https://thedozcompany.github.io/VaultFolio/theme-preview.html`
- `theme-preview.html` is now hosted on a dedicated `gh-pages` branch in this repo — never deleted by portfolio deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)