### PR TITLE
fix: update theme-preview URL in settings to VaultFolio GitHub Pages

### DIFF
--- a/main.js
+++ b/main.js
@@ -2569,7 +2569,7 @@ var VaultFolioSettingsTab = class extends import_obsidian3.PluginSettingTab {
     previewLink.style.cssText = "color: #7C3AED; font-size: 12px; cursor: pointer; display: inline-block; margin: -0.5rem 0 1rem 0; padding: 0 1rem; text-decoration: none;";
     previewLink.addEventListener("click", (e) => {
       e.preventDefault();
-      window.open("https://thedozcompany.github.io/vaultfolio-portfolio/theme-preview.html", "_blank");
+      window.open("https://thedozcompany.github.io/VaultFolio/theme-preview.html", "_blank");
     });
     containerEl.createEl("h3", { text: "Site Content" });
     new import_obsidian3.Setting(containerEl).setName("Nav Menu Links").setDesc("Format: 'Label: URL, Label: URL' (e.g. 'Work: #work, About: #about')").addTextArea(

--- a/src/ui/settingsTab.ts
+++ b/src/ui/settingsTab.ts
@@ -101,7 +101,7 @@ export class VaultFolioSettingsTab extends PluginSettingTab {
       "color: #7C3AED; font-size: 12px; cursor: pointer; display: inline-block; margin: -0.5rem 0 1rem 0; padding: 0 1rem; text-decoration: none;";
     previewLink.addEventListener("click", (e) => {
       e.preventDefault();
-      window.open("https://thedozcompany.github.io/vaultfolio-portfolio/theme-preview.html", "_blank");
+      window.open("https://thedozcompany.github.io/VaultFolio/theme-preview.html", "_blank");
     });
 
     // --- Site Content section ---


### PR DESCRIPTION
## Summary

The "Preview Themes" button in plugin settings was pointing to the portfolio repo URL which gets deleted on every VaultFolio deploy. Updated to the stable VaultFolio plugin repo GitHub Pages URL.

- `src/ui/settingsTab.ts` line 104: old URL → new URL
- `main.js` rebuilt

**Old:** `https://thedozcompany.github.io/vaultfolio-portfolio/theme-preview.html`
**New:** `https://thedozcompany.github.io/VaultFolio/theme-preview.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)