### PR TITLE
chore: bump version to 0.1.7

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "vaultfolio",
   "name": "VaultFolio",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "minAppVersion": "1.0.0",
   "description": "Turn your Obsidian notes into a live portfolio",
   "author": "Santhosh",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vaultfolio",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Turn your Obsidian notes into a live portfolio",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
Version bump to 0.1.7 for the theme-preview URL hotfix release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)