### PR TITLE
fix: normalize portfolioFolder path to prevent silent scan failures

### DIFF
--- a/main.js
+++ b/main.js
@@ -55,9 +55,11 @@ var Parser = class {
   }
   async getPublishedNotes() {
     var _a, _b, _c;
-    const folder = this.settings.portfolioFolder.replace(/\/+$/, "");
+    const folder = this.settings.portfolioFolder.trim().replace(/\/+$/, "");
+    if (!folder)
+      return [];
     const markdownFiles = this.app.vault.getMarkdownFiles().filter(
-      (f) => f.path === `${folder}/${f.name}` || f.path.startsWith(`${folder}/`)
+      (f) => f.path.startsWith(`${folder}/`)
     );
     const published = [];
     for (const file of markdownFiles) {
@@ -2543,7 +2545,7 @@ var VaultFolioSettingsTab = class extends import_obsidian3.PluginSettingTab {
     );
     new import_obsidian3.Setting(containerEl).setName("Portfolio folder").setDesc("Folder in your vault containing notes to publish.").addText(
       (text) => text.setPlaceholder("portfolio").setValue(this.plugin.settings.portfolioFolder).onChange(async (value) => {
-        this.plugin.settings.portfolioFolder = value;
+        this.plugin.settings.portfolioFolder = value.trim();
         await this.plugin.saveSettings();
       })
     );

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -37,10 +37,11 @@ export class Parser {
   constructor(private app: App, private settings: { portfolioFolder: string; coverProperty: string }) {}
 
   async getPublishedNotes(): Promise<PublishedNote[]> {
-    const folder = this.settings.portfolioFolder.replace(/\/+$/, "");
+    const folder = this.settings.portfolioFolder.trim().replace(/\/+$/, "");
+    if (!folder) return [];
 
     const markdownFiles = this.app.vault.getMarkdownFiles().filter((f: TFile) =>
-      f.path === `${folder}/${f.name}` || f.path.startsWith(`${folder}/`)
+      f.path.startsWith(`${folder}/`)
     );
 
     const published: PublishedNote[] = [];

--- a/src/ui/settingsTab.ts
+++ b/src/ui/settingsTab.ts
@@ -49,7 +49,7 @@ export class VaultFolioSettingsTab extends PluginSettingTab {
           .setPlaceholder("portfolio")
           .setValue(this.plugin.settings.portfolioFolder)
           .onChange(async (value) => {
-            this.plugin.settings.portfolioFolder = value;
+            this.plugin.settings.portfolioFolder = value.trim();
             await this.plugin.saveSettings();
           })
       );


### PR DESCRIPTION
## Problem

After a plugin update, some users found their notes stopped appearing in the sidebar and build produced an empty site. Workaround was creating a new folder and re-entering it in settings.

## Root Cause

Two issues in the folder path resolution:

1. **No `.trim()` when saving** (`settingsTab.ts`) — if the settings text input had any accidental whitespace (e.g. `"portfolio "`), it was saved as-is. The parser's `startsWith("portfolio /")` check would then never match any file path.

2. **No guard for empty string** (`parser.ts`) — if `portfolioFolder` was `""`, the filter became `f.path.startsWith("/")` which matches nothing in Obsidian. Zero notes, no error shown.

## Fix

- `parser.ts`: `.trim()` before stripping trailing slashes + early return for empty folder
- `parser.ts`: removed redundant `f.path === folder/f.name` check (covered by `startsWith`)
- `settingsTab.ts`: `.trim()` the value before saving

## Test plan

- [ ] Set portfolio folder to `"portfolio "` (trailing space) — notes should still be found
- [ ] Clear portfolio folder field — build returns 0 notes gracefully, no crash
- [ ] Normal folder name — behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)